### PR TITLE
:sparkles: Print built datetime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ dotnet publish *.csproj --output /home/site/wwwroot
 # To enable ssh & remote debugging on app service change the base image to the one below
 # FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice
 FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+ARG BUILD_TIMESTAMP
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 

--- a/HttpExample.cs
+++ b/HttpExample.cs
@@ -17,8 +17,10 @@ namespace deploy_issue_20241201
         [Function("HttpExample")]
         public IActionResult Run([HttpTrigger(AuthorizationLevel.Function, "get", "post")] HttpRequest req)
         {
-            _logger.LogInformation("C# HTTP trigger function processed a request.");
-            return new OkObjectResult("Welcome to Azure Functions!");
+            var buildDateTimeOffset = DateTimeOffset.FromUnixTimeMilliseconds(long.TryParse(Environment.GetEnvironmentVariable("BUILD_TIMESTAMP"), out var buildTimestamp) ? buildTimestamp : 0);
+            var buildDateTimeOffsetJst = TimeZoneInfo.ConvertTime(buildDateTimeOffset, TimeZoneInfo.FindSystemTimeZoneById("Tokyo Standard Time"));
+            _logger.LogInformation("C# HTTP trigger function built at {BuildDateTime} processed a request", buildDateTimeOffsetJst.ToString());
+            return new OkObjectResult($"Welcome to Azure Functions! Built at {buildDateTimeOffsetJst.ToString()}");
         }
     }
 }


### PR DESCRIPTION
- 区別がつくように、コンテナイメージのビルド時にタイムスタンプを焼き込んで、それをレスポンスに出力する
